### PR TITLE
Proper disposal of the client (#18)

### DIFF
--- a/TDLib.Tests/TdClientDisposeTests.cs
+++ b/TDLib.Tests/TdClientDisposeTests.cs
@@ -10,21 +10,12 @@ namespace TDLib.Tests
     {
         private class BlockableTdClient : TdClient
         {
-            private readonly ManualResetEventSlim _allowBeforeClosed;
             private readonly ManualResetEventSlim _allowBeforeStartClosing;
-            public readonly ManualResetEventSlim IsBlockedInBeforeClosed = new ManualResetEventSlim();
             public readonly ManualResetEventSlim IsBlockedInBeforeStartClosing = new ManualResetEventSlim();
             
-            public BlockableTdClient(ManualResetEventSlim allowBeforeClosed, ManualResetEventSlim allowBeforeStartClosing)
+            public BlockableTdClient(ManualResetEventSlim allowBeforeStartClosing)
             {
-                _allowBeforeClosed = allowBeforeClosed;
                 _allowBeforeStartClosing = allowBeforeStartClosing;
-            }
-
-            private protected override void BeforeClosed()
-            {
-                IsBlockedInBeforeClosed.Set();
-                _allowBeforeClosed.Wait();
             }
 
             private protected override void BeforeStartClosing()
@@ -38,39 +29,31 @@ namespace TDLib.Tests
         public async Task RaceConditionInDisposeCase()
         {
             using (var receiverUnblocked = new ManualResetEventSlim(false))
-            using (var closingUnblocked = new ManualResetEventSlim(false))
             {
                 // 1. Inject a blocking callback into the Receiver thread so the update from the Close command won't be
                 //    received by the client in time.
-                var client = new BlockableTdClient(receiverUnblocked, closingUnblocked)
+                var client = new BlockableTdClient(receiverUnblocked)
                 {
                     TimeoutToClose = TimeSpan.FromSeconds(1.0)
                 };
                 
-                // This test require a constant observer to be on the client, so it doesn't buffer the incoming events.
+                // 2. This test requires a constant observer to be on the client, so it doesn't buffer the incoming
+                //    events.
                 client.UpdateReceived += delegate { };
                 
-                // 2. Send a Close command call into the client. 
+                // 3. Send a Close command call into the client. 
                 _ = client.ExecuteAsync(new TdApi.Close());
                 
-                // 3. Wait for the client to be blocked *before* _isClosed is flipped.
-                client.IsBlockedInBeforeClosed.Wait();
-
-                // 4. Now call the Dispose method. It will check the _isClosed field (which hasn't been switched to true
-                //    yet), and then call the Close command (again).
+                // 4. Now call the Dispose method.
                 var disposeParallel = Task.Run(() => client.Dispose());
                 
-                // 5. Wait for thread to check the _isClosed:
+                // 5. Wait for a thread to be inside of the closing procedure.
                 client.IsBlockedInBeforeStartClosing.Wait();
                 
-                // 6. Now, after the _isClosed check happened, we may allow the receiver thread to unblock.
+                // 6. Now unblock the receiver thread.
                 receiverUnblocked.Set();
                 
-                // 7. And let's make sure the received queue is empty before proceeding:
-                Thread.Sleep(100);
-                closingUnblocked.Set();
-                
-                await disposeParallel; // will produce a timeout error in case of a race condition
+                await disposeParallel; // could produce a timeout error in case of a race condition
             }
         }
     }

--- a/TDLib.Tests/TdClientDisposeTests.cs
+++ b/TDLib.Tests/TdClientDisposeTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TdLib;
+using Xunit;
+
+namespace TDLib.Tests
+{
+    public class TdClientDisposeTests
+    {
+        private class BlockableTdClient : TdClient
+        {
+            private readonly ManualResetEventSlim _allowBeforeClosed;
+            private readonly ManualResetEventSlim _allowBeforeStartClosing;
+            public readonly ManualResetEventSlim IsBlockedInBeforeClosed = new ManualResetEventSlim();
+            public readonly ManualResetEventSlim IsBlockedInBeforeStartClosing = new ManualResetEventSlim();
+            
+            public BlockableTdClient(ManualResetEventSlim allowBeforeClosed, ManualResetEventSlim allowBeforeStartClosing)
+            {
+                _allowBeforeClosed = allowBeforeClosed;
+                _allowBeforeStartClosing = allowBeforeStartClosing;
+            }
+
+            private protected override void BeforeClosed()
+            {
+                IsBlockedInBeforeClosed.Set();
+                _allowBeforeClosed.Wait();
+            }
+
+            private protected override void BeforeStartClosing()
+            {
+                IsBlockedInBeforeStartClosing.Set();
+                _allowBeforeStartClosing.Wait();
+            }
+        }
+        
+        [Fact]
+        public async Task RaceConditionInDisposeCase()
+        {
+            using (var receiverUnblocked = new ManualResetEventSlim(false))
+            using (var closingUnblocked = new ManualResetEventSlim(false))
+            {
+                // 1. Inject a blocking callback into the Receiver thread so the update from the Close command won't be
+                //    received by the client in time.
+                var client = new BlockableTdClient(receiverUnblocked, closingUnblocked)
+                {
+                    TimeoutToClose = TimeSpan.FromSeconds(1.0)
+                };
+                
+                // This test require a constant observer to be on the client, so it doesn't buffer the incoming events.
+                client.UpdateReceived += delegate { };
+                
+                // 2. Send a Close command call into the client. 
+                _ = client.ExecuteAsync(new TdApi.Close());
+                
+                // 3. Wait for the client to be blocked *before* _isClosed is flipped.
+                client.IsBlockedInBeforeClosed.Wait();
+
+                // 4. Now call the Dispose method. It will check the _isClosed field (which hasn't been switched to true
+                //    yet), and then call the Close command (again).
+                var disposeParallel = Task.Run(() => client.Dispose());
+                
+                // 5. Wait for thread to check the _isClosed:
+                client.IsBlockedInBeforeStartClosing.Wait();
+                
+                // 6. Now, after the _isClosed check happened, we may allow the receiver thread to unblock.
+                receiverUnblocked.Set();
+                
+                // 7. And let's make sure the received queue is empty before proceeding:
+                Thread.Sleep(100);
+                closingUnblocked.Set();
+                
+                await disposeParallel; // will produce a timeout error in case of a race condition
+            }
+        }
+    }
+}

--- a/TDLib.Tests/TdClientExTests.cs
+++ b/TDLib.Tests/TdClientExTests.cs
@@ -12,8 +12,7 @@ namespace TDLib.Tests
             using (var client = new TdClient())
             {
                 var result = client.WaitForUpdate(
-                    update => update is TdApi.Update.UpdateAuthorizationState stateUpdate
-                              && stateUpdate.AuthorizationState is TdApi.AuthorizationState.AuthorizationStateClosed,
+                    update => update.IsAuthorizationStateClosed(),
                     TimeSpan.FromMinutes(1.0));
 
                 Assert.NotNull(result);

--- a/TDLib.Tests/TdClientExTests.cs
+++ b/TDLib.Tests/TdClientExTests.cs
@@ -1,0 +1,23 @@
+using System;
+using TdLib;
+using Xunit;
+
+namespace TDLib.Tests
+{
+    public class TdClientExTests
+    {
+        [Fact]
+        public void WaitForUpdateWorksProperly()
+        {
+            using (var client = new TdClient())
+            {
+                var result = client.WaitForUpdate(
+                    update => update is TdApi.Update.UpdateAuthorizationState stateUpdate
+                              && stateUpdate.AuthorizationState is TdApi.AuthorizationState.AuthorizationStateClosed,
+                    TimeSpan.FromMinutes(1.0));
+
+                Assert.NotNull(result);
+            }
+        }
+    }
+}

--- a/TDLib.Tests/TdClientUpdateTests.cs
+++ b/TDLib.Tests/TdClientUpdateTests.cs
@@ -12,10 +12,14 @@ namespace TDLib.Tests
             using (var client = new TdClient())
             {
                 var tcs = new TaskCompletionSource<TdApi.Update>();
-                client.UpdateReceived += (sender, update) =>
+
+                void Handler(object sender, TdApi.Update update)
                 {
                     tcs.SetResult(update);
-                };
+                    client.UpdateReceived -= Handler;
+                }
+
+                client.UpdateReceived += Handler; 
 
 #pragma warning disable 4014
                 client.ExecuteAsync(new TdApi.TestUseUpdate());

--- a/TDLib/Bindings/Receiver.cs
+++ b/TDLib/Bindings/Receiver.cs
@@ -6,9 +6,9 @@ using TdLib;
 
 namespace TDLib.Bindings
 {
-    internal class Receiver
+    internal class Receiver : IDisposable
     {
-        private readonly ManualResetEvent _stopped = new ManualResetEvent(false);
+        private readonly ManualResetEventSlim _stopped = new ManualResetEventSlim(false);
         private readonly TdJsonClient _tdJsonClient;
         private CancellationTokenSource _cts;
         
@@ -53,7 +53,12 @@ namespace TDLib.Bindings
         internal void Stop()
         {
             _cts.Cancel();
-            _stopped.WaitOne();
+            _stopped.Wait();
+        }
+
+        public void Dispose()
+        {
+            _stopped.Dispose();
         }
     }
 }

--- a/TDLib/Bindings/ReceiverEx.cs
+++ b/TDLib/Bindings/ReceiverEx.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+
+namespace TDLib.Bindings
+{
+    internal static class ReceiverEx
+    {
+        public delegate T ReceiverStateFunc<T>(ref Receiver.ReceiverInternalState state);
+        public static Task<T> Queue<T>(this Receiver receiver, ReceiverStateFunc<T> func)
+        {
+            var tcs = new TaskCompletionSource<T>();
+
+            receiver.ScheduleAction((ref Receiver.ReceiverInternalState state) =>
+            {
+                var result = func(ref state);
+                tcs.SetResult(result);
+            });
+
+            return tcs.Task;
+        }
+
+        public static Task Queue(this Receiver receiver, Receiver.ReceiverStateAction action) =>
+            receiver.Queue<object>((ref Receiver.ReceiverInternalState state) =>
+            {
+                action(ref state);
+                return null;
+            });
+    }
+}

--- a/TDLib/Properties/AssemblyInfo.cs
+++ b/TDLib/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TdLib.Tests")]

--- a/TDLib/TdClient.cs
+++ b/TDLib/TdClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -179,6 +179,7 @@ namespace TdLib
             
             _receiver.Stop();
             _receiver.Received -= OnReceived;
+            _receiver.Dispose();
             _receiver = null;
 
             if (_disposeJsonClient)

--- a/TDLib/TdClientEx.cs
+++ b/TDLib/TdClientEx.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+
+namespace TdLib
+{
+    public static class TdClientEx
+    {
+        public static async Task<TdApi.Update> WaitForUpdate(
+            this TdClient client, 
+            Func<TdApi.Update, bool> condition, 
+            TimeSpan timeout)
+        {
+            var tcs = new TaskCompletionSource<TdApi.Update>();
+            EventHandler<TdApi.Update> handler = (_, update) =>
+            {
+                if (condition(update))
+                {
+                    tcs.SetResult(update);
+                }
+            };
+
+            try
+            {
+                client.UpdateReceived += handler;
+
+                var delay = Task.Delay(timeout);
+                var result = await Task.WhenAny(tcs.Task, delay);
+                if (result == delay) return null;
+                
+                return tcs.Task.Result;
+            }
+            finally
+            {
+                client.UpdateReceived -= handler;
+            }
+        }
+    }
+}

--- a/TDLib/UpdateEx.cs
+++ b/TDLib/UpdateEx.cs
@@ -1,0 +1,9 @@
+namespace TdLib
+{
+    internal static class UpdateEx
+    {
+        public static bool IsAuthorizationStateClosed(this TdApi.Update update) =>
+            update is TdApi.Update.UpdateAuthorizationState stateUpdate
+            && stateUpdate.AuthorizationState is TdApi.AuthorizationState.AuthorizationStateClosed;
+    }
+}


### PR DESCRIPTION
Closes #18.

Calling `TdClient.Dispose` will now execute the `Close` command, and then will wait for the authentication state to be updated to Closed.

To perform that, a couple of auxiliary facilities were implemented:

1. There's now a method to wait for a particular `Update` event on `TdClient`.
2. `Receiver.Stop` will now only stop when all the receive calls are resolved. Beforehand, it was stopping in an asynchronous manner and thus could still be in a middle of `Receive()` call after the `Stop()` call has already been finished.
3. The biggest change: the `Receiver` now exposes a method that allows to queue an action into the underlying thread. `Receiver` thread now has an internal state, `ReceiverInternalState`, that stores the authentication state. The `ReceiverInternalState` is marked as a `ref struct` to prevent accidental sharing of it with any other threads, and thus prevent any race conditions.

### TODO

- [x] New functionality requires separate unit tests
- [x] There's still a race condition possible. Consider this situation:
1. Client calls the check `if (_isClosed) return`
2. `_isClosed` is equal to `false` yet, so it proceeds
3. At the same moment, server decides to close the authorization and the `Receiver` thread sets `_isClosed = true`
4. And now the client tries to execute the `Close` command and then waits for the authentication state to update

I'm planning to solve that by injecting the `if (_isClosed)` check into the `Receiver` thread itself. To do that, I plan to make a proper "Scheduler" from that thread (so external facilities could inject tasks into it that it will perform).

- [x] This particular race condition demands an additional test, too
- [x] Change the timeout in `WaitForUpdate` to cancellation token