### PR TITLE
Async behavior and test fixes

### DIFF
--- a/TDLib.Tests/TestSettings.cs
+++ b/TDLib.Tests/TestSettings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/TDLib/TdClient.cs
+++ b/TDLib/TdClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -145,7 +145,7 @@ namespace TdLib
             }
             
             var id = Interlocked.Increment(ref _taskId);
-            var tcs = new TaskCompletionSource<TResult>();
+            var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             function.Extra = id.ToString();
             _tasks.TryAdd(id, structure =>
@@ -192,8 +192,8 @@ namespace TdLib
 
         private async Task CloseAsync()
         {
-            var tcs = new TaskCompletionSource<TdApi.AuthorizationState>();
-            
+            var tcs = new TaskCompletionSource<TdApi.AuthorizationState>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             EventHandler<TdApi.AuthorizationState> handler = (sender, state) =>
             {
                 if (state is TdApi.AuthorizationState.AuthorizationStateClosed)


### PR DESCRIPTION
Callbacks shouldn't usually be called synchronously, because it could lead to reentrancy problems. E.g. we could try to close the client and wait for the result before leaving the receive method.

Test collection behavior was changed to circumvent #33.