### PR TITLE
Added static GlobalExecute and extracted Execute to a common private method

### DIFF
--- a/TDLib/TdJsonClient.cs
+++ b/TDLib/TdJsonClient.cs
@@ -65,12 +65,28 @@ namespace TdLib
             {
                 throw new ObjectDisposedException("TDLib JSON client was disposed");
             }
-            
+
+            return Execute(Bindings, _handle, data);
+        }
+
+        /// <summary>
+        /// Synchronously send JSON string to TDLib and get response
+        /// </summary>
+        public static string GlobalExecute(string data)
+            => GlobalExecute(Interop.AutoDetectBindings(), data);
+        /// <summary>
+        /// Synchronously send JSON string to TDLib and get response
+        /// </summary>
+        public static string GlobalExecute(ITdLibBindings bindings, string data) 
+            => Execute(bindings, IntPtr.Zero, data);
+
+        private static string Execute(ITdLibBindings bindings, IntPtr handle, string data) 
+        {
             var ptr = Interop.StringToIntPtr(data);
 
             try
             {
-                var res = Bindings.ClientExecute(_handle, ptr);
+                var res = bindings.ClientExecute(handle, ptr);
                 return Interop.IntPtrToString(res);
             }
             finally


### PR DESCRIPTION
Created private `Execute` method which received the bindings, handle and data.

Existing `Execute` method now calls the private `Execute` method using the instance `_handle` and `Bindings`.

New `GlobalExecute` method uses an `IntPtr.Zero` handle, and either uses `Interop.AutoDetectBindings` or accepts a bindings parameter.

This allows TDLib calls such as `setLogVerbosityLevel` or `setLogStream` before a client is created and output is produced.