### PR TITLE
(#88) Interop: allow public access to bindings autodetection

### DIFF
--- a/TDLib/Bindings/Interop.cs
+++ b/TDLib/Bindings/Interop.cs
@@ -6,9 +6,9 @@ using TDLib.Bindings;
 
 namespace TdLib.Bindings
 {
-    internal static class Interop
+    public static class Interop
     {
-        internal static ITdLibBindings AutoDetectBindings()
+        public static ITdLibBindings AutoDetectBindings()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {


### PR DESCRIPTION
Closes #88.

More precisely, adds an ability to easily access the `Bindings` instance before calling `TdClient` constructor.