### PR TITLE
(#90) TdClient: add analyzer for ConfigureAwait(), fix portability warnings

### DIFF
--- a/TDLib/TDLib.csproj
+++ b/TDLib/TDLib.csproj
@@ -6,6 +6,10 @@
     <Version>1.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.675">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Closes #90.

This PR does the following:
- adds a `Meziantou.Analyzer` package which has a Roslyn analyzer that warns about `await` without `ConfigureAwait(false)` (which, as I believe, is a must-have for a library which is designed to be used with GUI programs)
- fixes all such warnings across the project (not much thankfully)
- fixes a couple of other warnings, such as calling `int.TryParse` and `int.ToString()` without passing an invariant culture

I have also thought about implementing `IAsyncDisposable` in `TdClient`, but TdSharp targets .NET Standard 2.0, and `IAsyncDisposable` isn't yet available there, unfortunately. So, not today.