### PR TITLE
(#114) TDLib.Bindings (obsolete namespace): mark obsoletes as error: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Array items are now deserialized to their actual types ([#146](https://github.com/egramtel/tdsharp/issues/146)).
 
+### Changed
+- All the items in `TDLib.Bindings` namespace (the previously mentioned case-only issue) were marked as `Obsolete(error: true)`. Basic API compatibility is preserved, source compatibility is not.
+
 ## [1.8.1.1] - 2022-06-26
 ### Changed
 - `ITdLibBindings`, `TdLibBindingsExtensions` and `TdLogLevel` were moved from `TDLib.Bindings` to `TdLib.Bindings` (case-only change in the namespace), since the old namespace was created in an error. A compatibility layer is created to keep the old types available.

--- a/TdLib/LegacyCompat.cs
+++ b/TdLib/LegacyCompat.cs
@@ -3,12 +3,12 @@
 // ReSharper disable once CheckNamespace
 namespace TDLib.Bindings;
 
-// TODO[#114]: Mark these types as "error: true" in the next update.
+// TODO[#114]: Delete these obsolete types in the next update.
 
-[Obsolete("Use TdLib.Bindings.ITdLibBindings instead (check the namespace case)")]
+[Obsolete("Use TdLib.Bindings.ITdLibBindings instead (check the namespace case)", error: true)]
 public interface ITdLibBindings : TdLib.Bindings.ITdLibBindings {}
 
-[Obsolete("Use TdLib.Bindings.TdLibBindingsExtensions instead (check the namespace case)")]
+[Obsolete("Use TdLib.Bindings.TdLibBindingsExtensions instead (check the namespace case)", error: true)]
 public static class TdLibBindingsExtensions
 {
     public static void SetLogFilePath(this ITdLibBindings bindings, string path)
@@ -22,7 +22,7 @@ public static class TdLibBindingsExtensions
     }
 }
 
-[Obsolete("Use TdLib.Bindings.TdLogLevel instead (check the namespace case)")]
+[Obsolete("Use TdLib.Bindings.TdLogLevel instead (check the namespace case)", error: true)]
 public enum TdLogLevel
 {
     Fatal = 0,


### PR DESCRIPTION
#114, step 2.