### PR TITLE
CI: disable fail-fast, migrate to x64 macOS runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:
-        image: [ macos-latest, ubuntu-latest, windows-latest ]
+        image: [ macos-13, # TODO: Migrate to ARM64 image
+                 ubuntu-latest, windows-latest ]
+      fail-fast: false
     env:
       DOTNET_NOLOGO: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:
-        image: [ macos-13, # TODO: Migrate to ARM64 image
+        image: [ macos-13, # TODO[#191]: Migrate to ARM64 image
                  ubuntu-latest, windows-latest ]
       fail-fast: false
     env:


### PR DESCRIPTION
Right now, tdlib.native (the one we use for tests) doesn't support the ARM64 macOS runner yet
(https://github.com/ForNeVeR/tdlib.native/issues/74).